### PR TITLE
Add more detailed country statistics

### DIFF
--- a/sql/country_statistics.sql
+++ b/sql/country_statistics.sql
@@ -1,5 +1,6 @@
 CREATE MATERIALIZED VIEW country_statistics AS
   WITH country_counts AS (
+    -- Collect country-related changesets with edit counts and associate with hashtags
     SELECT cc.changeset_id,
         countries.id,
         countries.code,
@@ -10,12 +11,14 @@ CREATE MATERIALIZED VIEW country_statistics AS
         JOIN countries ON ((cc.country_id = countries.id)))
         FULL OUTER JOIN changesets_hashtags hts ON (hts.changeset_id = cc.changeset_id))
     ), user_edits AS (
+      -- Associate user ids with changesets/edit count
       SELECT c_chg.country_id,
           c_chg.edit_count,
           c.user_id
         FROM (changesets_countries c_chg
           JOIN changesets c ON (c.id = c_chg.changeset_id))
     ), country_edits AS (
+      -- Aggregate edit counts per user (ignore UID 0)
       SELECT country_id,
           user_id,
           sum(edit_count) AS edits
@@ -23,16 +26,19 @@ CREATE MATERIALIZED VIEW country_statistics AS
         WHERE user_id <> 0
         GROUP BY country_id, user_id
     ), grouped_user_edits AS (
+      -- Rank user edit totals per country
       SELECT *,
           ROW_NUMBER() OVER (PARTITION BY country_id ORDER BY edits DESC) as rank
         FROM country_edits
     ), json_country_edits AS (
+      -- Collapse top ten user edit totals into JSON object
       SELECT country_id,
           json_agg(json_build_object('user', user_id, 'count', edits)) AS edits
         FROM grouped_user_edits
         WHERE rank <= 10
         GROUP BY country_id
     ), ht_edits AS (
+      -- Associate hashtags with aggregate edit counts per country
       SELECT cc.id as country_id,
           hts.hashtag,
           sum(edit_count) as edit_count
@@ -40,40 +46,43 @@ CREATE MATERIALIZED VIEW country_statistics AS
           JOIN hashtags hts ON cc.hashtag_id = hts.id)
         GROUP BY cc.id, hts.hashtag
     ), grouped_hts AS (
+      -- Rank edit counts per country
       SELECT *,
           ROW_NUMBER() OVER (PARTITION BY country_id ORDER BY edit_count DESC) as rank
         FROM ht_edits
     ), ht_json AS (
+      -- Collapse top ten most active hashtags per country into JSON object
       SELECT country_id,
           json_agg(json_build_object('hashtag', hashtag, 'count', edit_count)) as hashtag_edits
         FROM grouped_hts
         WHERE rank <= 10
         GROUP BY country_id
     ), agg_stats AS (
-    SELECT cc.id as country_id,
-        sum(chg.road_km_added) AS road_km_added,
-        sum(chg.road_km_modified) AS road_km_modified,
-        sum(chg.waterway_km_added) AS waterway_km_added,
-        sum(chg.waterway_km_modified) AS waterway_km_modified,
-        sum(chg.coastline_km_added) AS coastline_km_added,
-        sum(chg.coastline_km_modified) AS coastline_km_modified,
-        sum(chg.roads_added) AS roads_added,
-        sum(chg.roads_modified) AS roads_modified,
-        sum(chg.waterways_added) AS waterways_added,
-        sum(chg.waterways_modified) AS waterways_modified,
-        sum(chg.coastlines_added) AS coastlines_added,
-        sum(chg.coastlines_modified) AS coastlines_modified,
-        sum(chg.buildings_added) AS buildings_added,
-        sum(chg.buildings_modified) AS buildings_modified,
-        sum(chg.pois_added) AS pois_added,
-        sum(chg.pois_modified) AS pois_modified,
-        max(coalesce(chg.closed_at, chg.created_at)) AS last_edit,
-        max(COALESCE(chg.closed_at, chg.created_at, chg.updated_at)) AS updated_at,
-        count(*) AS changeset_count,
-        sum(cc.edit_count) AS edit_count
-      FROM (changesets chg
-        JOIN country_counts cc ON ((cc.changeset_id = chg.id)))
-      GROUP BY cc.id
+      -- Aggregate statistics per country
+      SELECT cc.id as country_id,
+          sum(chg.road_km_added) AS road_km_added,
+          sum(chg.road_km_modified) AS road_km_modified,
+          sum(chg.waterway_km_added) AS waterway_km_added,
+          sum(chg.waterway_km_modified) AS waterway_km_modified,
+          sum(chg.coastline_km_added) AS coastline_km_added,
+          sum(chg.coastline_km_modified) AS coastline_km_modified,
+          sum(chg.roads_added) AS roads_added,
+          sum(chg.roads_modified) AS roads_modified,
+          sum(chg.waterways_added) AS waterways_added,
+          sum(chg.waterways_modified) AS waterways_modified,
+          sum(chg.coastlines_added) AS coastlines_added,
+          sum(chg.coastlines_modified) AS coastlines_modified,
+          sum(chg.buildings_added) AS buildings_added,
+          sum(chg.buildings_modified) AS buildings_modified,
+          sum(chg.pois_added) AS pois_added,
+          sum(chg.pois_modified) AS pois_modified,
+          max(coalesce(chg.closed_at, chg.created_at)) AS last_edit,
+          max(COALESCE(chg.closed_at, chg.created_at, chg.updated_at)) AS updated_at,
+          count(*) AS changeset_count,
+          sum(cc.edit_count) AS edit_count
+        FROM (changesets chg
+          JOIN country_counts cc ON ((cc.changeset_id = chg.id)))
+        GROUP BY cc.id
     )
   SELECT agg.country_id,
       countries.name AS country_name,
@@ -105,4 +114,4 @@ CREATE MATERIALIZED VIEW country_statistics AS
       FULL OUTER JOIN ht_json hts ON (agg.country_id = hts.country_id)
       JOIN countries ON agg.country_id = countries.id);
 
-CREATE UNIQUE INDEX country_statistics_id ON country_statistics(country_id);
+CREATE UNIQUE INDEX country_statistics_id ON country_statistics(country_code);

--- a/sql/country_statistics_working.sql
+++ b/sql/country_statistics_working.sql
@@ -1,0 +1,61 @@
+CREATE MATERIALIZED VIEW country_statistics AS
+  WITH country_counts AS (
+    SELECT cc.changeset_id,
+        countries.id AS country_id,
+        countries.name AS country_name,
+        cc.edit_count
+      FROM (changesets_countries cc
+        JOIN countries ON ((cc.country_id = countries.id)))
+    ), agg_stats AS (
+    SELECT cc.country_id,
+        cc.country_name,
+        array_agg(chg.id) AS changesets,
+        sum(chg.road_km_added) AS road_km_added,
+        sum(chg.road_km_modified) AS road_km_modified,
+        sum(chg.waterway_km_added) AS waterway_km_added,
+        sum(chg.waterway_km_modified) AS waterway_km_modified,
+        sum(chg.coastline_km_added) AS coastline_km_added,
+        sum(chg.coastline_km_modified) AS coastline_km_modified,
+        sum(chg.roads_added) AS roads_added,
+        sum(chg.roads_modified) AS roads_modified,
+        sum(chg.waterways_added) AS waterways_added,
+        sum(chg.waterways_modified) AS waterways_modified,
+        sum(chg.coastlines_added) AS coastlines_added,
+        sum(chg.coastlines_modified) AS coastlines_modified,
+        sum(chg.buildings_added) AS buildings_added,
+        sum(chg.buildings_modified) AS buildings_modified,
+        sum(chg.pois_added) AS pois_added,
+        sum(chg.pois_modified) AS pois_modified,
+        max(coalesce(chg.closed_at, chg.created_at)) AS last_edit,
+        max(COALESCE(chg.closed_at, chg.created_at, chg.updated_at)) AS updated_at,
+        count(*) AS changeset_count,
+        sum(cc.edit_count) as edit_count
+      FROM (changesets chg
+        JOIN country_counts cc ON ((cc.changeset_id = chg.id)))
+      GROUP BY cc.country_id, cc.country_name
+    )
+  SELECT agg_stats.country_id,
+     agg_stats.country_name,
+     agg_stats.road_km_added,
+     agg_stats.road_km_modified,
+     agg_stats.waterway_km_added,
+     agg_stats.waterway_km_modified,
+     agg_stats.coastline_km_added,
+     agg_stats.coastline_km_modified,
+     agg_stats.roads_added,
+     agg_stats.roads_modified,
+     agg_stats.waterways_added,
+     agg_stats.waterways_modified,
+     agg_stats.coastlines_added,
+     agg_stats.coastlines_modified,
+     agg_stats.buildings_added,
+     agg_stats.buildings_modified,
+     agg_stats.pois_added,
+     agg_stats.pois_modified,
+     agg_stats.last_edit,
+     agg_stats.updated_at,
+     agg_stats.changeset_count,
+     agg_stats.edit_count
+    FROM agg_stats;
+
+CREATE UNIQUE INDEX country_statistics_id ON country_statistics(country_id);

--- a/src/main/scala/osmesa/server/stats/CountryStats.scala
+++ b/src/main/scala/osmesa/server/stats/CountryStats.scala
@@ -1,0 +1,88 @@
+package osmesa.server.stats
+
+import osmesa.server.model._
+
+import doobie._
+import doobie.implicits._
+import doobie.postgres._
+import doobie.postgres.implicits._
+import cats._
+import cats.data._
+import cats.effect._
+import cats.implicits._
+import io.circe._
+import io.circe.jawn._
+import io.circe.syntax._
+import io.circe.generic.extras.Configuration
+import io.circe.generic.extras.semiauto._
+import fs2._
+import org.http4s.circe._
+import org.http4s._
+import org.http4s.dsl.Http4sDsl
+import org.http4s.server.blaze.BlazeBuilder
+import org.http4s.server.HttpMiddleware
+import org.http4s.server.middleware.{GZip, CORS, CORSConfig}
+import org.http4s.headers.{Location, `Content-Type`}
+import org.postgresql.util.PGobject
+
+import scala.concurrent.duration._
+
+case class CountryStats(
+  countryId: Long,
+  name: Option[String],
+  kmRoadsAdd: Option[Double],
+  kmRoadsMod: Option[Double],
+  kmWaterwaysAdd: Option[Double],
+  kmWaterwaysMod: Option[Double],
+  kmCoastlineAdd: Option[Double],
+  kmCoastlineMod: Option[Double],
+  roadsAdd: Option[Int],
+  roadsMod: Option[Int],
+  waterwaysAdd: Option[Int],
+  waterwaysMod: Option[Int],
+  coastlinesAdd: Option[Int],
+  coastlinesMod: Option[Int],
+  buildingsAdd: Option[Int],
+  buildingsMod: Option[Int],
+  poiAdd: Option[Int],
+  poiMod: Option[Int],
+  lastEdit: Option[java.sql.Timestamp],
+  updatedAt: Option[java.sql.Timestamp],
+  changesetCount: Option[Int],
+  editCount: Option[Int]
+)
+
+object CountryStats {
+  implicit val customConfig: Configuration = Configuration.default.withSnakeCaseMemberNames.withDefaults
+  implicit val countryStatsDecoder: Decoder[CountryStats] = deriveDecoder
+  implicit val countryStatsEncoder: Encoder[CountryStats] = deriveEncoder
+
+  private val selectF = fr"""
+      SELECT
+        country_id, country_name, road_km_added, road_km_modified, waterway_km_added, waterway_km_modified,
+        coastline_km_added, coastline_km_modified, roads_added, roads_modified, waterways_added, waterways_modified,
+        coastlines_added, coastlines_modified, buildings_added, buildings_modified, pois_added, pois_modified,
+        last_edit, updated_at, changeset_count, edit_count
+      FROM
+        country_statistics
+    """
+
+  def byId(id: Long)(implicit xa: Transactor[IO]): IO[Either[OsmStatError, CountryStats]] =
+    (selectF ++ fr"WHERE country_id = $id")
+      .query[CountryStats]
+      .option
+      .transact(xa)
+      .map {
+        case Some(country) => Right(country)
+        case None => Left(IdNotFoundError("country", id))
+      }
+
+  def getPage(pageNum: Int, pageSize: Int = 25)(implicit xa: Transactor[IO]): IO[ResultPage[CountryStats]] = {
+    val offset = pageNum * pageSize + 1
+    (selectF ++ fr"ORDER BY id ASC LIMIT $pageSize OFFSET $offset")
+      .query[CountryStats]
+      .to[List]
+      .map({ ResultPage(_, pageNum) })
+      .transact(xa)
+  }
+}

--- a/src/main/scala/osmesa/server/stats/CountryStats.scala
+++ b/src/main/scala/osmesa/server/stats/CountryStats.scala
@@ -49,7 +49,9 @@ case class CountryStats(
   lastEdit: Option[java.sql.Timestamp],
   updatedAt: Option[java.sql.Timestamp],
   changesetCount: Option[Int],
-  editCount: Option[Int]
+  editCount: Option[Int],
+  userEdits: Json,
+  hashtagEdits: Json
 )
 
 object CountryStats {
@@ -62,19 +64,19 @@ object CountryStats {
         country_id, country_name, road_km_added, road_km_modified, waterway_km_added, waterway_km_modified,
         coastline_km_added, coastline_km_modified, roads_added, roads_modified, waterways_added, waterways_modified,
         coastlines_added, coastlines_modified, buildings_added, buildings_modified, pois_added, pois_modified,
-        last_edit, updated_at, changeset_count, edit_count
+        last_edit, updated_at, changeset_count, edit_count, user_edit_counts, hashtag_edits
       FROM
         country_statistics
     """
 
-  def byId(id: Long)(implicit xa: Transactor[IO]): IO[Either[OsmStatError, CountryStats]] =
-    (selectF ++ fr"WHERE country_id = $id")
+  def byId(code: String)(implicit xa: Transactor[IO]): IO[Either[OsmStatError, CountryStats]] =
+    (selectF ++ fr"WHERE country_code = $code")
       .query[CountryStats]
       .option
       .transact(xa)
       .map {
         case Some(country) => Right(country)
-        case None => Left(IdNotFoundError("country", id))
+        case None => Left(IdNotFoundError("country", code))
       }
 
   def getPage(pageNum: Int, pageSize: Int = 25)(implicit xa: Transactor[IO]): IO[ResultPage[CountryStats]] = {

--- a/src/main/scala/osmesa/server/stats/StatsRouter.scala
+++ b/src/main/scala/osmesa/server/stats/StatsRouter.scala
@@ -78,6 +78,12 @@ class StatsRouter(trans: Transactor[IO]) extends Http4sDsl[IO] {
         country <- eitherResult(io)
       } yield country
 
+    case GET -> Root / "country-stats" / IntVar(countryId) =>
+      for {
+        io <- CountryStats.byId(countryId)
+        result <- eitherResult(io)
+      } yield result
+
     case GET -> Root / "changesets-countries" :? OptionalPageQueryParamMatcher(pageNum) =>
       Ok(ChangesetCountry.getPage(pageNum.getOrElse(0)).map(_.asJson))
 

--- a/src/main/scala/osmesa/server/stats/StatsRouter.scala
+++ b/src/main/scala/osmesa/server/stats/StatsRouter.scala
@@ -78,7 +78,7 @@ class StatsRouter(trans: Transactor[IO]) extends Http4sDsl[IO] {
         country <- eitherResult(io)
       } yield country
 
-    case GET -> Root / "country-stats" / IntVar(countryId) =>
+    case GET -> Root / "country-stats" / countryId =>
       for {
         io <- CountryStats.byId(countryId)
         result <- eitherResult(io)


### PR DESCRIPTION
It may be useful for a user to be able to inspect aggregate changes to a country.  This PR supplies a means to access that data.  This is mostly encapsulated in a materialized view in the DB, and comes with a new web server endpoint, `country-stats`, that can be queried with the numerical country code normally found in the `countries` table.

This first pass almost certainly needs the materialized view to be augmented with more detailed information of interest.