### PR TITLE
Temporary fix to total_edits column of changesets table

### DIFF
--- a/sql/hashtag_user_statistics.sql
+++ b/sql/hashtag_user_statistics.sql
@@ -1,6 +1,28 @@
 DROP MATERIALIZED VIEW IF EXISTS hashtag_user_statistics;
 CREATE MATERIALIZED VIEW hashtag_user_statistics AS
-  WITH general AS (
+  WITH totaledits AS (
+    SELECT
+      id,
+      coalesce(sum((t.v->>0)::numeric),0) as total_edits
+    FROM changesets, jsonb_each(counts) AS t(k,v)
+    GROUP BY id
+  ),
+  changesets AS (
+    SELECT
+        changesets.id,
+        changesets.measurements,
+        changesets.counts,
+        totaledits.total_edits as total_edits,
+        changesets.editor,
+        changesets.user_id,
+        changesets.created_at,
+        changesets.closed_at,
+        changesets.augmented_diffs,
+        changesets.updated_at
+    FROM changesets full outer join totaledits
+    ON changesets.id = totaledits.id
+  ),
+  general AS (
       SELECT
       user_id,
       hashtag_id,

--- a/sql/user_statistics.sql
+++ b/sql/user_statistics.sql
@@ -1,6 +1,28 @@
 DROP MATERIALIZED VIEW IF EXISTS user_statistics;
 CREATE MATERIALIZED VIEW user_statistics AS
-  WITH general AS (
+  WITH totaledits AS (
+    SELECT
+      id,
+      coalesce(sum((t.v->>0)::numeric),0) as total_edits
+    FROM changesets, jsonb_each(counts) AS t(k,v)
+    GROUP BY id
+  ),
+  changesets AS (
+    SELECT
+        changesets.id,
+        changesets.measurements,
+        changesets.counts,
+        totaledits.total_edits as total_edits,
+        changesets.editor,
+        changesets.user_id,
+        changesets.created_at,
+        changesets.closed_at,
+        changesets.augmented_diffs,
+        changesets.updated_at
+    FROM changesets full outer join totaledits
+    ON changesets.id = totaledits.id
+  ),
+  general AS (
     SELECT
       user_id,
       array_agg(id) changesets,


### PR DESCRIPTION
**THIS PR IS A RECORD OF A TEMPORARY FIX.  DO NOT MERGE**

We discovered a problem in azavea/osmesa that causes the `total_edits` column in the `changesets` table to diverge from the sum of the disaggregated counts in the `counts` column during streaming update.  For various reasons, it made more sense to patch together a quick fix through the materialized views of the DB than to fix the DB.  The permanent fix of the DB will come later and be applied to the azavea/osmesa repo.  This PR will be closed at that time.  I'm making this hacky fix available in this PR for posterity and good record keeping.